### PR TITLE
fix: dark mode support for team settings + invite modal

### DIFF
--- a/frontend/app/components/InviteMemberModal.vue
+++ b/frontend/app/components/InviteMemberModal.vue
@@ -111,7 +111,7 @@ function handleClose() {
 }
 
 .modal {
-  background: var(--color-white);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   width: 100%;
   max-width: 420px;
@@ -123,13 +123,13 @@ function handleClose() {
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-6);
-  border-bottom: 1px solid var(--color-gray-200);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .modal__title {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-gray-900);
+  color: var(--color-text-primary);
   margin: 0;
 }
 
@@ -138,14 +138,14 @@ function handleClose() {
   border: none;
   padding: var(--spacing-2);
   cursor: pointer;
-  color: var(--color-gray-500);
+  color: var(--color-text-muted);
   border-radius: var(--radius-md);
   transition: all var(--transition-fast);
 }
 
 .modal__close:hover {
-  background: var(--color-gray-100);
-  color: var(--color-gray-700);
+  background: var(--color-background);
+  color: var(--color-text-secondary);
 }
 
 .modal__close svg {
@@ -171,6 +171,6 @@ function handleClose() {
   justify-content: flex-end;
   gap: var(--spacing-3);
   padding: var(--spacing-6);
-  border-top: 1px solid var(--color-gray-200);
+  border-top: 1px solid var(--color-border);
 }
 </style>

--- a/frontend/app/components/MembersTable.vue
+++ b/frontend/app/components/MembersTable.vue
@@ -167,7 +167,7 @@ function formatDate(dateStr: string): string {
 <style scoped>
 .members-table-wrapper {
   overflow-x: auto;
-  border: 1px solid var(--color-gray-200);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
 }
 
@@ -180,15 +180,15 @@ function formatDate(dateStr: string): string {
 .members-table th {
   text-align: left;
   padding: var(--spacing-3) var(--spacing-4);
-  background: var(--color-gray-50);
+  background: var(--color-surface);
   font-weight: var(--font-weight-medium);
-  color: var(--color-gray-700);
-  border-bottom: 1px solid var(--color-gray-200);
+  color: var(--color-text-secondary);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .members-table td {
   padding: var(--spacing-3) var(--spacing-4);
-  border-bottom: 1px solid var(--color-gray-100);
+  border-bottom: 1px solid var(--color-border);
   vertical-align: middle;
 }
 
@@ -197,11 +197,11 @@ function formatDate(dateStr: string): string {
 }
 
 .members-table tr:hover {
-  background: var(--color-gray-50);
+  background: var(--color-surface);
 }
 
 .row-expanded {
-  background: var(--color-gray-50);
+  background: var(--color-surface);
 }
 
 .loading-cell,
@@ -255,13 +255,13 @@ function formatDate(dateStr: string): string {
 }
 
 .status-active {
-  background: var(--color-green-100);
-  color: var(--color-green-700);
+  background: color-mix(in srgb, var(--color-success) 14%, var(--color-surface));
+  color: var(--color-text-primary);
 }
 
 .status-inactive {
-  background: var(--color-gray-100);
-  color: var(--color-gray-600);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
 }
 
 .cell-date {
@@ -281,10 +281,11 @@ function formatDate(dateStr: string): string {
 
 .role-select {
   padding: var(--spacing-1) var(--spacing-2);
-  border: 1px solid var(--color-gray-300);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
-  background: var(--color-white);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
 }
 
 .icon-btn {
@@ -302,11 +303,11 @@ function formatDate(dateStr: string): string {
 }
 
 .icon-btn.success {
-  color: var(--color-green-600);
+  color: var(--color-success);
 }
 
 .icon-btn.success:hover {
-  color: var(--color-green-700);
+  color: color-mix(in srgb, var(--color-success) 75%, var(--color-text-primary));
 }
 
 .icon-btn svg {

--- a/frontend/app/pages/app/settings/members.vue
+++ b/frontend/app/pages/app/settings/members.vue
@@ -156,12 +156,12 @@ function handleInvited() {
 .members-page__header h1 {
   font-size: var(--font-size-2xl);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-gray-900);
+  color: var(--color-text-primary);
   margin: 0 0 var(--spacing-1) 0;
 }
 
 .members-page__subtitle {
-  color: var(--color-gray-500);
+  color: var(--color-text-muted);
   margin: 0;
 }
 
@@ -178,14 +178,14 @@ function handleInvited() {
 }
 
 .feedback--success {
-  background: var(--color-green-50);
-  color: var(--color-green-700);
-  border: 1px solid var(--color-green-200);
+  background: color-mix(in srgb, var(--color-success) 14%, var(--color-surface));
+  color: var(--color-text-primary);
+  border: 1px solid color-mix(in srgb, var(--color-success) 50%, var(--color-border));
 }
 
 .feedback--error {
-  background: var(--color-red-50);
-  color: var(--color-red-700);
-  border: 1px solid var(--color-red-200);
+  background: var(--color-error-bg);
+  color: var(--color-error);
+  border: 1px solid var(--color-error-border);
 }
 </style>


### PR DESCRIPTION
## Summary\n- align team settings page feedback colors with semantic tokens for light/dark themes\n- update members table surfaces/borders/status chips to use theme-aware color variables\n- update invite member modal shell/header/footer to theme-aware colors\n\n## Issues\n- Closes #26\n- Closes #27\n\n## Validation\n- npm run build (frontend)