### PR TITLE
fix: dark mode support for team settings and invite modal

### DIFF
--- a/frontend/app/components/InviteMemberModal.vue
+++ b/frontend/app/components/InviteMemberModal.vue
@@ -124,13 +124,13 @@ function handleClose() {
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-6);
-  border-bottom: 1px solid var(--color-gray-200);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .modal__title {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-gray-900);
+  color: var(--color-text-primary);
   margin: 0;
 }
 
@@ -139,14 +139,14 @@ function handleClose() {
   border: none;
   padding: var(--spacing-2);
   cursor: pointer;
-  color: var(--color-gray-500);
+  color: var(--color-text-secondary);
   border-radius: var(--radius-md);
   transition: all var(--transition-fast);
 }
 
 .modal__close:hover {
-  background: var(--color-gray-100);
-  color: var(--color-gray-700);
+  background: var(--color-background);
+  color: var(--color-text-primary);
 }
 
 .modal__close svg {
@@ -172,6 +172,6 @@ function handleClose() {
   justify-content: flex-end;
   gap: var(--spacing-3);
   padding: var(--spacing-6);
-  border-top: 1px solid var(--color-gray-200);
+  border-top: 1px solid var(--color-border);
 }
 </style>

--- a/frontend/app/components/MembersTable.vue
+++ b/frontend/app/components/MembersTable.vue
@@ -180,10 +180,10 @@ function formatDate(dateStr: string): string {
 .members-table th {
   text-align: left;
   padding: var(--spacing-3) var(--spacing-4);
-  background: var(--color-gray-50);
+  background: var(--color-surface);
   font-weight: var(--font-weight-medium);
-  color: var(--color-gray-700);
-  border-bottom: 1px solid var(--color-gray-200);
+  color: var(--color-text-primary);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .members-table td {
@@ -299,7 +299,7 @@ function formatDate(dateStr: string): string {
 }
 
 .icon-btn:hover {
-  color: var(--color-gray-700);
+  color: var(--color-text-primary);
 }
 
 .icon-btn.success {

--- a/frontend/app/pages/app/settings/members.vue
+++ b/frontend/app/pages/app/settings/members.vue
@@ -156,12 +156,12 @@ function handleInvited() {
 .members-page__header h1 {
   font-size: var(--font-size-2xl);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-gray-900);
+  color: var(--color-text-primary);
   margin: 0 0 var(--spacing-1) 0;
 }
 
 .members-page__subtitle {
-  color: var(--color-gray-500);
+  color: var(--color-text-secondary);
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary\n- replace hardcoded light-only colors in Team Members settings and Invite Member modal\n- use semantic theme tokens for borders, surfaces, and text so dark mode renders correctly\n\n## Issues\n- Closes #26\n- Closes #27\n\n## Validation\n- npm run build (frontend)