### PR TITLE
fix: remove remember me from login form

### DIFF
--- a/frontend/app/pages/login.vue
+++ b/frontend/app/pages/login.vue
@@ -14,7 +14,6 @@ const router = useRouter()
 const email = ref('')
 const password = ref('')
 const showPassword = ref(false)
-const rememberMe = ref(false)
 const errors = ref<{ email?: string; password?: string; general?: string }>({})
 const isSubmitting = ref(false)
 
@@ -42,7 +41,7 @@ async function handleSubmit() {
 
   await new Promise(resolve => setTimeout(resolve, 300))
 
-  const result = await auth.login(email.value, password.value, rememberMe.value)
+  const result = await auth.login(email.value, password.value, false)
 
   if (result.success) {
     router.push('/app/dashboard')
@@ -106,11 +105,7 @@ async function handleSubmit() {
         <p v-if="errors.password" class="field-error" role="alert">{{ errors.password }}</p>
       </div>
 
-      <div class="form-options">
-        <label class="checkbox-label">
-          <input v-model="rememberMe" type="checkbox" :disabled="isSubmitting">
-          <span>Remember me</span>
-        </label>
+      <div class="form-options form-options--single">
         <NuxtLink to="/forgot-password" class="forgot-link">Forgot password?</NuxtLink>
       </div>
 
@@ -279,24 +274,8 @@ async function handleSubmit() {
   align-items: center;
 }
 
-.checkbox-label {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  font-size: var(--font-size-sm);
-  color: var(--color-gray-600);
-  cursor: pointer;
-}
-
-.checkbox-label input {
-  width: var(--spacing-4);
-  height: var(--spacing-4);
-  cursor: pointer;
-  accent-color: var(--color-primary-600);
-}
-
-.checkbox-label input:disabled {
-  cursor: not-allowed;
+.form-options--single {
+  justify-content: flex-end;
 }
 
 .forgot-link {


### PR DESCRIPTION
## Summary\n- remove the remember me checkbox from login UI\n- keep login flow unchanged by passing a static false for remember flag\n\n## Issues\n- Closes #29\n\n## Validation\n- npm run build (frontend)