### PR TITLE
fix: dark mode styling for team settings and invite modal

### DIFF
--- a/frontend/app/components/InviteMemberModal.vue
+++ b/frontend/app/components/InviteMemberModal.vue
@@ -111,7 +111,8 @@ function handleClose() {
 }
 
 .modal {
-  background: var(--color-white);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-xl);
   width: 100%;
   max-width: 420px;

--- a/frontend/app/components/MembersTable.vue
+++ b/frontend/app/components/MembersTable.vue
@@ -281,10 +281,11 @@ function formatDate(dateStr: string): string {
 
 .role-select {
   padding: var(--spacing-1) var(--spacing-2);
-  border: 1px solid var(--color-gray-300);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
-  background: var(--color-white);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
 }
 
 .icon-btn {

--- a/frontend/app/pages/app/settings/index.vue
+++ b/frontend/app/pages/app/settings/index.vue
@@ -174,21 +174,21 @@ async function handleSave() {
   justify-content: space-between;
   align-items: center;
   padding: var(--spacing-4);
-  background: var(--color-red-50);
-  border: 1px solid var(--color-red-200);
+  background: color-mix(in srgb, var(--color-error) 12%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-error) 45%, var(--color-border));
   border-radius: var(--radius-lg);
 }
 
 .danger-action h3 {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-red-700);
+  color: var(--color-text-primary);
   margin: 0 0 var(--spacing-1) 0;
 }
 
 .danger-action p {
   font-size: var(--font-size-sm);
-  color: var(--color-red-600);
+  color: var(--color-text-secondary);
   margin: 0;
 }
 </style>

--- a/frontend/app/pages/app/settings/members.vue
+++ b/frontend/app/pages/app/settings/members.vue
@@ -178,14 +178,14 @@ function handleInvited() {
 }
 
 .feedback--success {
-  background: var(--color-green-50);
-  color: var(--color-green-700);
-  border: 1px solid var(--color-green-200);
+  background: color-mix(in srgb, var(--color-success) 12%, var(--color-surface));
+  color: var(--color-text-primary);
+  border: 1px solid color-mix(in srgb, var(--color-success) 40%, var(--color-border));
 }
 
 .feedback--error {
-  background: var(--color-red-50);
-  color: var(--color-red-700);
-  border: 1px solid var(--color-red-200);
+  background: color-mix(in srgb, var(--color-error) 14%, var(--color-surface));
+  color: var(--color-text-primary);
+  border: 1px solid color-mix(in srgb, var(--color-error) 45%, var(--color-border));
 }
 </style>


### PR DESCRIPTION
## Summary
- fixed dark mode contrast/surface styles in team settings areas
- updated invite member modal and role select surfaces to use theme tokens
- adjusted success/error and danger states for better dark-mode readability

## Issues
- Closes #26
- Closes #27

## Validation
- npm run build ✅
- npm run test:e2e ⚠️ fails due to existing broad baseline failures unrelated to this bundle (CI non-blocking)
