### PR TITLE
fix: style theme dropdown to match app design system

### DIFF
--- a/frontend/app/components/ui/ThemeToggle.vue
+++ b/frontend/app/components/ui/ThemeToggle.vue
@@ -34,7 +34,7 @@ const options = [
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: var(--spacing-1) var(--spacing-2);
+  padding: var(--spacing-1) var(--spacing-3);
   transition: background-color var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
 }
 
@@ -51,10 +51,17 @@ const options = [
   border: 0;
   background: transparent;
   color: inherit;
+  font-family: inherit;
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   cursor: pointer;
-  padding-right: var(--spacing-4);
+  appearance: none;
+  color-scheme: light dark;
+  padding: var(--spacing-1) var(--spacing-5) var(--spacing-1) 0;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-position: right 0 center;
+  background-repeat: no-repeat;
+  background-size: 1.125em;
 }
 
 .theme-toggle__select:focus {


### PR DESCRIPTION
## Summary
Updates the ThemeToggle \<select>\ to use the same design tokens and styling patterns as the app's \Select.vue\ component, removing native browser dropdown appearance.

### Changes (ThemeToggle.vue)
- Add \ppearance: none\ to strip native browser select chrome
- Add \color-scheme: light dark\ for proper dark-mode option rendering
- Add custom SVG chevron indicator (matches the pattern used in \ui/Select.vue\)
- Inherit \ont-family\ for consistent typography
- Adjust padding to accommodate the custom chevron

### Before / After
Before: native OS select dropdown with default styling (see issue screenshot)
After: consistent pill-shaped toggle using app design tokens, with custom chevron and proper dark mode support

Resolves #39