### PR TITLE
fix: resolve dotnet format whitespace errors

### DIFF
--- a/api/ContentLocalizationSaaS.Api/Middleware/ObservabilityMiddleware.cs
+++ b/api/ContentLocalizationSaaS.Api/Middleware/ObservabilityMiddleware.cs
@@ -15,12 +15,13 @@ public sealed class ObservabilityMiddleware(RequestDelegate next, ILogger<Observ
         context.Response.Headers[CorrelationHeader] = correlationId;
         context.Items[CorrelationHeader] = correlationId;
 
-        using (logger.BeginScope(new Dictionary<string, object>
-               {
-                   ["CorrelationId"] = correlationId,
-                   ["RequestPath"] = context.Request.Path.ToString(),
-                   ["RequestMethod"] = context.Request.Method
-               }))
+        var scope = new Dictionary<string, object>
+        {
+            ["CorrelationId"] = correlationId,
+            ["RequestPath"] = context.Request.Path.ToString(),
+            ["RequestMethod"] = context.Request.Method
+        };
+        using (logger.BeginScope(scope))
         {
             var started = DateTime.UtcNow;
             await next(context);

--- a/api/ContentLocalizationSaaS.Application/ContentItemsContracts.cs
+++ b/api/ContentLocalizationSaaS.Application/ContentItemsContracts.cs
@@ -22,7 +22,7 @@ public sealed class CreateContentItemRequestValidator : AbstractValidator<Create
             .NotEmpty()
             .MaximumLength(200)
             .Matches(KeyPattern)
-            .WithMessage("Key must use lowercase letters/numbers and separators (., _, -).") ;
+            .WithMessage("Key must use lowercase letters/numbers and separators (., _, -).");
         RuleFor(x => x.Source).NotEmpty().MaximumLength(4000);
         RuleFor(x => x.Status).NotEmpty().MaximumLength(32);
         RuleFor(x => x.Context).MaximumLength(1000);


### PR DESCRIPTION
## Summary
Fixes the CI dotnet format --verify-no-changes failure by correcting whitespace formatting violations.

### Changes
- **ObservabilityMiddleware.cs** — Extract inline dictionary initializer to a local variable, eliminating alignment-based indentation (7 extra chars per line) that violated format rules
- **ContentItemsContracts.cs** — Remove trailing space before semicolon on line 25

### Validation
- These are mechanical whitespace fixes; no logic changes
- CI \dotnet format\ step should now pass

Resolves #38